### PR TITLE
Refactor of episode loading/playback flow to use messages

### DIFF
--- a/internal/ui/tui/models/anime_list.go
+++ b/internal/ui/tui/models/anime_list.go
@@ -37,10 +37,7 @@ type AnimeListModel struct {
 	animeService         *service.AnimeService
 	playerService        *player.PlayerService
 	width, height        int
-	loading              bool
-	loadingMsg           string
 	loadError            error
-	spinner              spinner.Model
 	filters              AnimeFilterSet
 	cursor               int
 	allAnime             []*domain.Anime // All anime from the service
@@ -69,8 +66,6 @@ func NewAnimeListModel(cfg *config.Config, animeService *service.AnimeService) *
 		config:               cfg,
 		animeService:         animeService,
 		playerService:        player.NewPlayerService(cfg),
-		loading:              false,
-		spinner:              s,
 		filters:              defaultFilters,
 		cursor:               0,
 		allAnime:             []*domain.Anime{},
@@ -138,14 +133,6 @@ func (m *AnimeListModel) HandleAnimeListError(err error) (Model, tea.Cmd) {
 
 // View renders the anime list model
 func (m *AnimeListModel) View() string {
-	if m.loading {
-		return styles.CenteredView(
-			m.width,
-			m.height,
-			fmt.Sprintf("%s %s", m.spinner.View(), m.loadingMsg),
-		)
-	}
-
 	if m.loadError != nil {
 		errorMsg := fmt.Sprintf("Error loading anime list: %v\n\nPress 'r' to retry.", m.loadError)
 		return styles.CenteredView(
@@ -191,9 +178,4 @@ func (m *AnimeListModel) getSelectedAnime() *domain.Anime {
 		return nil
 	}
 	return animeList[m.cursor]
-}
-
-// DisableLoading disables the loading state
-func (m *AnimeListModel) DisableLoading() {
-	m.loading = false
 }

--- a/internal/ui/tui/models/loading.go
+++ b/internal/ui/tui/models/loading.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PizzaHomicide/hisame/internal/log"
 	"github.com/PizzaHomicide/hisame/internal/ui/tui/styles"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -71,6 +72,7 @@ func (m *LoadingModel) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, cmd
 	}
 
+	log.Warn("Loading model received message it can't handle", "message", msg)
 	return m, nil
 }
 


### PR DESCRIPTION
Primary goal is to remove the built-in loading state from the AnimeListModel and use the LoadingModel itself.

This is still WIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined loading indicator management by removing the spinner and loading state from the anime list view. Loading states are now handled with dedicated loading screens.
  - Improved playback and episode loading logic for clearer and more consistent feedback during operations.
  - Enhanced internal logging for better diagnostics when unexpected messages are received during loading.
- **Bug Fixes**
  - Prevented stacking of multiple loading screens for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->